### PR TITLE
fix: enable bones-movement domain route

### DIFF
--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -18,7 +18,7 @@ export const DOMAINS_BY_CATEGORY: Record<CategorySlug, { slug: string; labelKey:
   'child-body': [
     { slug: 'eyes', labelKey: 'domain.eyes', ready: true },
     { slug: 'breathing', labelKey: 'domain.breathing', ready: true },
-    { slug: 'bones-movement', labelKey: 'domain.bonesMovement', ready: false },
+    { slug: 'bones-movement', labelKey: 'domain.bonesMovement', ready: true },
     { slug: 'teeth', labelKey: 'domain.teeth', ready: false },
     { slug: 'nutrition', labelKey: 'domain.nutrition', ready: true },
     { slug: 'skin', labelKey: 'domain.skin', ready: true },


### PR DESCRIPTION
## Summary
- Set `ready: true` for bones-movement domain in `src/config/domains.ts`
- Content (EN + ZH articles) already existed but the route was never generated, causing a 404

## Test plan
- [ ] Visit `/en/child-body/bones-movement/` — should render the domain page
- [ ] Visit `/zh/child-body/bones-movement/` — same
- [ ] `npm run build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)